### PR TITLE
Rename the module sogo3 -> sogo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   symlinks:
-    sogo3: "#{source_dir}"
+    sogo: "#{source_dir}"
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,3 +1,2 @@
-sogo3::configuration_file: '/usr/local/etc/sogo3/sogo.conf'
-sogo3::package: 'sogo3'
-sogo3::service: 'sogod'
+sogo::configuration_file: '/usr/local/etc/sogo/sogo.conf'
+sogo::service: 'sogod'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,3 @@
-sogo3::configuration_file: '/etc/sogo/sogo.conf'
-sogo3::package: 'sogo'
-sogo3::service: 'sogo'
+sogo::configuration_file: '/etc/sogo/sogo.conf'
+sogo::package: 'sogo'
+sogo::service: 'sogo'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
-class sogo3::config {
-  file { $sogo3::configuration_file:
+class sogo::config {
+  file { $sogo::configuration_file:
     ensure  => file,
-    content => epp('sogo3/sogo.conf.epp'),
+    content => epp('sogo/sogo.conf.epp'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
-class sogo3 (
+class sogo (
   String                    $language = 'English',
   String                    $time_zone = 'America/Montreal',
   String                    $login_module = 'Calendar',
   Boolean                   $password_change_enabled = false,
-  Array[Sogo3::Usersource]  $user_sources = [],
+  Array[Sogo::Usersource]   $user_sources = [],
   String                    $profile_url = 'postgresql://sogo:sogo@localhost:5432/sogo/sogo_user_profile',
   String                    $folder_info_url = 'postgresql://sogo:sogo@localhost:5432/sogo/sogo_folder_info',
   String                    $sessions_folder_url = 'postgresql://sogo:sogo@localhost:5432/sogo/sogo_sessions_folder',
@@ -16,16 +16,16 @@ class sogo3 (
   String                    $service = undef,
 ) {
   if $use_custom_repo {
-    contain sogo3::repo
+    contain sogo::repo
 
-    Class['sogo3::repo']
-    -> Class['sogo3::package']
+    Class['sogo::repo']
+    -> Class['sogo::package']
   }
-  contain sogo3::package
-  contain sogo3::config
-  contain sogo3::service
+  contain sogo::package
+  contain sogo::config
+  contain sogo::service
 
-  Class['sogo3::package']
-  -> Class['sogo3::config']
-  ~> Class['sogo3::service']
+  Class['sogo::package']
+  -> Class['sogo::config']
+  ~> Class['sogo::service']
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,5 +1,5 @@
-class sogo3::package {
-  package { $sogo3::package:
+class sogo::package {
+  package { $sogo::package:
     ensure => installed,
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,12 +1,12 @@
-class sogo3::repo {
-  if $sogo3::repository_username and $sogo3::repository_password {
-    $location = "https://${sogo3::repository_username}:${sogo3::repository_password}@packages.inverse.ca/SOGo/release/3/debian/"
+class sogo::repo {
+  if $sogo::repository_username and $sogo::repository_password {
+    $location = "https://${sogo::repository_username}:${sogo::repository_password}@packages.inverse.ca/SOGo/release/3/debian/"
   } else {
     $location = 'https://packages.inverse.ca/SOGo/nightly/3/debian/'
   }
 
   apt::source { 'inverse_ca':
-    ensure   => $sogo3::ensure_repository,
+    ensure   => $sogo::ensure_repository,
     comment  => 'Inverse repository for SOGo',
     location => $location,
     release  => $facts['lsbdistcodename'],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,5 @@
-class sogo3::service {
-  service { $sogo3::service:
+class sogo::service {
+  service { $sogo::service:
     ensure => running,
     enable => true,
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'sogo3' do
+describe 'sogo' do
   let(:params) do
     {
       user_sources: user_sources,

--- a/templates/sogo.conf.epp
+++ b/templates/sogo.conf.epp
@@ -16,9 +16,9 @@
    * **************************************************************************/
 
   /* Database configuration (mysql:// or postgresql://) */
-  SOGoProfileURL = "<%= $sogo3::profile_url %>";
-  OCSFolderInfoURL = "<%= $sogo3::folder_info_url %>";
-  OCSSessionsFolderURL = "<%= $sogo3::sessions_folder_url %>";
+  SOGoProfileURL = "<%= $sogo::profile_url %>";
+  OCSFolderInfoURL = "<%= $sogo::folder_info_url %>";
+  OCSSessionsFolderURL = "<%= $sogo::sessions_folder_url %>";
 
   /* Mail */
   //SOGoDraftsFolderName = Drafts;
@@ -39,7 +39,7 @@
   //SOGoFoldersSendEMailNotifications = NO;
 
   /* Authentication */
-  SOGoPasswordChangeEnabled = <%= bool2str($sogo3::password_change_enabled, 'YES', 'NO') %>;
+  SOGoPasswordChangeEnabled = <%= bool2str($sogo::password_change_enabled, 'YES', 'NO') %>;
 
   /* LDAP authentication example */
   //SOGoUserSources = (
@@ -80,7 +80,7 @@
   //);
 
   SOGoUserSources = (
-<% $sogo3::user_sources.each |$user_source| { -%>
+<% $sogo::user_sources.each |$user_source| { -%>
     {
       <%-
         $fields = {
@@ -173,9 +173,9 @@
   //SOGoTrustProxyAuthentication = NO;
 
   /* General */
-  SOGoLanguage = <%= $sogo3::language %>;
-  SOGoTimeZone = <%= $sogo3::time_zone %>;
-  SOGoLoginModule = <%= $sogo3::login_module %>;
+  SOGoLanguage = <%= $sogo::language %>;
+  SOGoTimeZone = <%= $sogo::time_zone %>;
+  SOGoLoginModule = <%= $sogo::login_module %>;
   //SOGoCalendarDefaultRoles = (
   //  PublicDAndTViewer,
   //  ConfidentialDAndTViewer

--- a/types/usersource.pp
+++ b/types/usersource.pp
@@ -1,4 +1,4 @@
-type Sogo3::Usersource = Struct[
+type Sogo::Usersource = Struct[
   {
     type                    => Enum['ldap', 'sql'],
     cn_field_name           => Optional[String],


### PR DESCRIPTION
On Debian Buster, the sogo package is in fact SOGo 4.  FreeBSD has
www/sogo3 and www/sogo4 to choose from, but both install a similar
configuration to the same directory (SOGo 4 is a continuation of SOGo 3,
and the update is straighforward).

Rename the package so that the user does not expect it to install SOGo 3
by default, and actually install SOGo 4 when both SOGo 3 and 4 are
available.