### PR TITLE
Manage configuration file ownership and mode

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,6 +55,9 @@ The following parameters are available in the `sogo` class:
 * [`configuration_file`](#-sogo--configuration_file)
 * [`package`](#-sogo--package)
 * [`service`](#-sogo--service)
+* [`configuration_group`](#-sogo--configuration_group)
+* [`configuration_owner`](#-sogo--configuration_owner)
+* [`configuration_mode`](#-sogo--configuration_mode)
 * [`workers_count`](#-sogo--workers_count)
 * [`listen_queue_size`](#-sogo--listen_queue_size)
 * [`port`](#-sogo--port)
@@ -288,6 +291,28 @@ Package name
 Data type: `String[1]`
 
 Ensure parameter for the SOGo package
+
+##### <a name="-sogo--configuration_group"></a>`configuration_group`
+
+Data type: `String[1]`
+
+Group of the SOGo configuration file
+
+##### <a name="-sogo--configuration_owner"></a>`configuration_owner`
+
+Data type: `String[1]`
+
+User of the SOGo configuration file
+
+Default value: `'root'`
+
+##### <a name="-sogo--configuration_mode"></a>`configuration_mode`
+
+Data type: `Stdlib::Filemode`
+
+Permissions of the SOGo configuration file
+
+Default value: `'0640'`
 
 ##### <a name="-sogo--workers_count"></a>`workers_count`
 

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,2 +1,3 @@
 sogo::configuration_file: '/usr/local/etc/sogo/sogo.conf'
+sogo::configuration_group: 'sogod'
 sogo::service: 'sogod'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,4 @@
 sogo::configuration_file: '/etc/sogo/sogo.conf'
+sogo::configuration_group: 'sogo'
 sogo::package: 'sogo'
 sogo::service: 'sogo'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,9 @@ class sogo::config {
 
   file { $sogo::configuration_file:
     ensure  => file,
+    owner   => $sogo::configuration_owner,
+    group   => $sogo::configuration_group,
+    mode    => $sogo::configuration_mode,
     content => epp('sogo/sogo.conf.epp'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,10 +11,17 @@
 # @param configuration_file Path to SOGo configuration file
 # @param package Package name
 # @param service Ensure parameter for the SOGo package
+# @param configuration_group Group of the SOGo configuration file
+# @param configuration_owner User of the SOGo configuration file
+# @param configuration_mode Permissions of the SOGo configuration file
 class sogo (
   String[1]               $configuration_file,
   String[1]               $package,
   String[1]               $service,
+
+  String[1]               $configuration_group,
+  String[1]               $configuration_owner = 'root',
+  Stdlib::Filemode        $configuration_mode = '0640',
 
   # General settings
 


### PR DESCRIPTION
This file contain the password used to connect to the SOGo database and
the ones used to reach LDAP servers, so should definitively not be
readable by all users.

Make sure the file is only readable by the sogod daemon.
