### PR TITLE
Remove duplicate key from configuration Hash

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1569,6 +1569,9 @@ Alias of `Enum['ObjectViewer', 'ObjectEditor', 'ObjectCreator', 'ObjectEraser']`
 
 Describe a SOGo domain
 
+* **See also**
+  * https://www.sogo.nu/files/docs/SOGoInstallationGuide.html
+
 Alias of
 
 ```puppet
@@ -1593,7 +1596,7 @@ Struct[{
     Optional[create_identities_disabled]             => Boolean,
 
     # Authentication using LDAP
-    Optional[ldap_contact_info_attribute]            => String[1],
+    # ldap_contact_info_attribute (duplicate entry, kept to match documentation)
     Optional[ldap_query_limit]                       => String[1],
     Optional[ldap_query_timeout]                     => Integer[0],
     Optional[ldap_group_expansion_enabled]           => Boolean,

--- a/types/domain.pp
+++ b/types/domain.pp
@@ -1,4 +1,6 @@
 # @summary Describe a SOGo domain
+#
+# @see https://www.sogo.nu/files/docs/SOGoInstallationGuide.html
 type Sogo::Domain = Struct[
   {
     # General Preferences
@@ -21,7 +23,7 @@ type Sogo::Domain = Struct[
     Optional[create_identities_disabled]             => Boolean,
 
     # Authentication using LDAP
-    Optional[ldap_contact_info_attribute]            => String[1],
+    # ldap_contact_info_attribute (duplicate entry, kept to match documentation)
     Optional[ldap_query_limit]                       => String[1],
     Optional[ldap_query_timeout]                     => Integer[0],
     Optional[ldap_group_expansion_enabled]           => Boolean,


### PR DESCRIPTION
The key is present twice in the documentation, so in order to match the
documentation it was also introduced twice in the code.

Puppet lint now detect such inconsistencies, so make it happy.

This fix CI.
